### PR TITLE
Fix the maximum value for the sac-sma pfree parameter

### DIFF
--- a/parameters.libsonnet
+++ b/parameters.libsonnet
@@ -330,7 +330,7 @@ local sacsma = {
     },
     {
       init: 0.05,
-      max: 0.05,
+      max: 0.5,
       min: 0,
       name: 'pfree',
     },


### PR DESCRIPTION
This sets the correct maximum value for the `pfree` parameter.